### PR TITLE
v0.5.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clanker"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Gregory Meyer <gregjm@umich.edu>"]
 edition = "2018"
 description = "Minimalistic command prompt for fish."
@@ -9,10 +9,10 @@ readme = "README.md"
 repository = "https://github.com/Gregory-Meyer/clanker"
 
 [dependencies]
+dirs = "2.0"
 libc = "0.2"
 libgit2-sys = "0.9"
 unicode-segmentation = "1.3"
-dirs = "2.0"
 
 [[bin]]
 name = "clanker-prompt"

--- a/src/right_prompt.rs
+++ b/src/right_prompt.rs
@@ -59,20 +59,11 @@ fn make_prompt() -> String {
     }
 }
 
-macro_rules! try_option {
-    ($x:expr) => {
-        match $x {
-            Some(x) => x,
-            None => return None,
-        }
-    };
-}
-
 fn repo_head() -> Option<String> {
     let is_dirty_thread = thread::spawn(repository_is_dirty);
 
-    let repo = try_option!(Repository::open_from_env());
-    let identifier = try_option!(identify_head(&repo));
+    let repo = Repository::open_from_env()?;
+    let identifier = identify_head(&repo)?;
 
     if is_dirty_thread.join().ok().unwrap_or(false) {
         Some(format!("{} *", identifier))
@@ -82,12 +73,12 @@ fn repo_head() -> Option<String> {
 }
 
 fn identify_head(repo: &Repository) -> Option<String> {
-    let head = try_option!(repo.head());
+    let head = repo.head()?;
 
     if let Some(name) = head.branch_name() {
         Some(name.to_string_lossy().into_owned())
     } else {
-        let head_commit = try_option!(head.peel_to_commit()); // this had better point to a commit...
+        let head_commit = head.peel_to_commit()?; // this had better point to a commit...
         let tags = repo
             .tags_pointing_to(&head_commit)
             .unwrap_or_else(|| Vec::new());


### PR DESCRIPTION
* refactor `compress::gct::GraphemeClusterTrie` to simplify its logic, remove unnecessary generics, and insert strings iteratively instead of recursively
* refactor [`clanker_right_prompt.rs`] to use the `?` operator instead of my hand-rolled `try_option!` macro