### PR TITLE
v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clanker"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clanker"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Gregory Meyer <me@gregjm.dev>"]
 edition = "2018"
 description = "Minimalistic command prompt for fish."

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -45,8 +45,9 @@ impl IntoStringLossy for PathBuf {
     }
 }
 
-pub fn compress(path: &Path, min_home_dir_uid: u64) -> io::Result<String> {
-    let (without_prefix, mut buf, mut compressed) = without_prefix(path, min_home_dir_uid)?;
+pub fn compress(path: &Path, min_home_dir_uid: u64, max_home_dir_uid: u64) -> io::Result<String> {
+    let (without_prefix, mut buf, mut compressed) =
+        without_prefix(path, min_home_dir_uid, max_home_dir_uid)?;
 
     let mut components: Vec<_> = without_prefix.components().collect();
 
@@ -136,7 +137,11 @@ pub fn compress(path: &Path, min_home_dir_uid: u64) -> io::Result<String> {
     Ok(compressed)
 }
 
-fn without_prefix(path: &Path, min_home_dir_uid: u64) -> io::Result<(&Path, PathBuf, String)> {
+fn without_prefix(
+    path: &Path,
+    min_home_dir_uid: u64,
+    max_home_dir_uid: u64,
+) -> io::Result<(&Path, PathBuf, String)> {
     if let Some(home_dir) = dirs::home_dir() {
         if let Ok(without_prefix) = path.strip_prefix(&home_dir) {
             return Ok((without_prefix, home_dir, "~".to_string()));
@@ -168,7 +173,7 @@ fn without_prefix(path: &Path, min_home_dir_uid: u64) -> io::Result<(&Path, Path
             let mut fields = fields.skip(1); // skip password
             let uid: u64 = str::from_utf8(fields.next()?).ok()?.parse().ok()?;
 
-            if uid < min_home_dir_uid {
+            if uid < min_home_dir_uid || uid > max_home_dir_uid {
                 return None;
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,19 +78,19 @@ fn main() {
             SubCommand::with_name("prompt")
                 .about("Left side command prompt")
                 .arg(
-                    Arg::with_name("unpriviliged_cursor")
+                    Arg::with_name("unprivileged_cursor")
                         .short("u")
-                        .long("unpriviliged-cursor")
+                        .long("unprivileged-cursor")
                         .value_name("CURSOR")
-                        .help("Cursor used when the current user is unpriviliged")
+                        .help("Cursor used when the current user is unprivileged")
                         .default_value(">"),
                 )
                 .arg(
-                    Arg::with_name("priviliged_cursor")
+                    Arg::with_name("privileged_cursor")
                         .short("p")
-                        .long("priviliged-cursor")
+                        .long("privileged-cursor")
                         .value_name("CURSOR")
-                        .help("Cursor used when the current user is priviliged")
+                        .help("Cursor used when the current user is privileged")
                         .default_value("#"),
                 )
                 .arg(
@@ -140,8 +140,8 @@ fn main() {
         .get_matches();
 
     if let Some(matches) = matches.subcommand_matches("prompt") {
-        let unpriviliged_cursor = matches.value_of("unpriviliged_cursor").unwrap();
-        let priviliged_cursor = matches.value_of("priviliged_cursor").unwrap();
+        let unprivileged_cursor = matches.value_of("unprivileged_cursor").unwrap();
+        let privileged_cursor = matches.value_of("privileged_cursor").unwrap();
         let compressed_working_directory = compressed_working_directory(matches);
 
         if matches.is_present("no_username_hostname") {
@@ -149,13 +149,13 @@ fn main() {
                 print!(
                     "{}{} ",
                     compressed_working_directory.red(),
-                    priviliged_cursor
+                    privileged_cursor
                 );
             } else {
                 print!(
                     "{}{} ",
                     compressed_working_directory.green(),
-                    unpriviliged_cursor
+                    unprivileged_cursor
                 );
             }
         } else {
@@ -168,7 +168,7 @@ fn main() {
                     username,
                     hostname,
                     compressed_working_directory.red(),
-                    priviliged_cursor
+                    privileged_cursor
                 );
             } else {
                 print!(
@@ -176,7 +176,7 @@ fn main() {
                     username,
                     hostname,
                     compressed_working_directory.green(),
-                    unpriviliged_cursor
+                    unprivileged_cursor
                 );
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ fn main() {
         .short("w")
         .long("working-directory")
         .value_name("DIRECTORY")
-        .help("Path to use as the current working directory.")
+        .help("Path to use as the current working directory")
         .env("PWD");
 
     let matches = app_from_crate!()
@@ -76,13 +76,13 @@ fn main() {
         .setting(AppSettings::SubcommandRequired)
         .subcommand(
             SubCommand::with_name("prompt")
-                .about("Left side command prompt.")
+                .about("Left side command prompt")
                 .arg(
                     Arg::with_name("unpriviliged_cursor")
                         .short("u")
                         .long("unpriviliged-cursor")
                         .value_name("CURSOR")
-                        .help("Cursor used when the current user is unpriviliged.")
+                        .help("Cursor used when the current user is unpriviliged")
                         .default_value(">"),
                 )
                 .arg(
@@ -90,14 +90,14 @@ fn main() {
                         .short("p")
                         .long("priviliged-cursor")
                         .value_name("CURSOR")
-                        .help("Cursor used when the current user is priviliged.")
+                        .help("Cursor used when the current user is priviliged")
                         .default_value("#"),
                 )
                 .arg(
                     Arg::with_name("no_username_hostname")
                         .short("S")
                         .long("no-username-hostname")
-                        .help("If set, the current username and hostname will not be output."),
+                        .help("If set, the current username and hostname will not be output"),
                 )
                 .arg(min_home_dir_uid_arg.clone())
                 .arg(max_home_dir_uid_arg.clone())
@@ -105,13 +105,13 @@ fn main() {
         )
         .subcommand(
             SubCommand::with_name("right-prompt")
-                .about("Right side command prompt.")
+                .about("Right side command prompt")
                 .arg(
                     Arg::with_name("return_code")
                         .short("r")
                         .long("return-code")
                         .value_name("CODE")
-                        .help("Return code from the last run command.")
+                        .help("Return code from the last run command")
                         .default_value("0")
                         .validator(|maybe_return_code| {
                             if maybe_return_code.parse::<i32>().is_err() {
@@ -124,13 +124,13 @@ fn main() {
         )
         .subcommand(
             SubCommand::with_name("title")
-                .about("Window title for terminal emulators.")
+                .about("Window title for terminal emulators")
                 .arg(
                     Arg::with_name("current")
                         .short("c")
                         .long("currently-running")
                         .value_name("COMMAND")
-                        .help("Name of the currently running command.")
+                        .help("Name of the currently running command")
                         .takes_value(true),
                 )
                 .arg(min_home_dir_uid_arg.clone())

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,12 @@ fn main() {
                         .help("Cursor used when the current user is priviliged.")
                         .default_value("#"),
                 )
+                .arg(
+                    Arg::with_name("no_username_hostname")
+                        .short("S")
+                        .long("no-username-hostname")
+                        .help("If set, the current username and hostname will not be output."),
+                )
                 .arg(min_home_dir_uid_arg.clone())
                 .arg(max_home_dir_uid_arg.clone())
                 .arg(working_directory_arg.clone()),
@@ -138,25 +144,41 @@ fn main() {
         let priviliged_cursor = matches.value_of("priviliged_cursor").unwrap();
         let compressed_working_directory = compressed_working_directory(matches);
 
-        let (username, is_root) = username_and_is_root();
-        let hostname = hostname();
-
-        if is_root {
-            print!(
-                "{}@{} {}{} ",
-                username,
-                hostname,
-                compressed_working_directory.red(),
-                priviliged_cursor
-            );
+        if matches.is_present("no_username_hostname") {
+            if is_root() {
+                print!(
+                    "{}{} ",
+                    compressed_working_directory.red(),
+                    priviliged_cursor
+                );
+            } else {
+                print!(
+                    "{}{} ",
+                    compressed_working_directory.green(),
+                    unpriviliged_cursor
+                );
+            }
         } else {
-            print!(
-                "{}@{} {}{} ",
-                username,
-                hostname,
-                compressed_working_directory.green(),
-                unpriviliged_cursor
-            );
+            let (username, is_root) = username_and_is_root();
+            let hostname = hostname();
+
+            if is_root {
+                print!(
+                    "{}@{} {}{} ",
+                    username,
+                    hostname,
+                    compressed_working_directory.red(),
+                    priviliged_cursor
+                );
+            } else {
+                print!(
+                    "{}@{} {}{} ",
+                    username,
+                    hostname,
+                    compressed_working_directory.green(),
+                    unpriviliged_cursor
+                );
+            }
         }
     } else if let Some(matches) = matches.subcommand_matches("right-prompt") {
         let return_code: i32 = matches.value_of("return_code").unwrap().parse().unwrap();
@@ -181,6 +203,10 @@ fn main() {
     } else {
         unreachable!();
     }
+}
+
+fn is_root() -> bool {
+    unsafe { libc::geteuid() == 0 }
 }
 
 fn username_and_is_root() -> (String, bool) {


### PR DESCRIPTION
* set default minimum home directory UID to 1000 and add optional argument -x,--max-home-dir-uid, with default value 60000 (#14)
* add optional argument -S,--no-username-hostname, which elides `<username>@<hostname>` from the output of clanker-prompt when set (#13)
* remove periods from argument and subcommand help text ([35cb0bd](https://github.com/Gregory-Meyer/clanker/commit/35cb0bdc2cc4d9d1ffad0ace76989cb85352ab63))